### PR TITLE
Phalcon 4: Replace paginate->total_items with last

### DIFF
--- a/src/Pagination/PhalconFrameworkPaginatorAdapter.php
+++ b/src/Pagination/PhalconFrameworkPaginatorAdapter.php
@@ -74,7 +74,7 @@ class PhalconFrameworkPaginatorAdapter implements PaginatorInterface
      */
     public function getCount()
     {
-        return $this->paginator->total_pages;
+        return $this->paginator->last;
     }
 
     /**

--- a/test/Pagination/PhalconFrameworkPaginatorAdapterTest.php
+++ b/test/Pagination/PhalconFrameworkPaginatorAdapterTest.php
@@ -17,7 +17,7 @@ class PhalconFrameworkPaginatorAdapterTest extends TestCase
         $resultset->next        = 4;
         $resultset->previous    = 2;
         $resultset->total_items = 50;
-        $resultset->total_pages = 10;
+        $resultset->last = 10;
 
         $adapter = new PhalconFrameworkPaginatorAdapter($resultset);
         $this->assertInstanceOf('League\Fractal\Pagination\PaginatorInterface', $adapter);
@@ -25,7 +25,7 @@ class PhalconFrameworkPaginatorAdapterTest extends TestCase
         $this->assertSame(10, $adapter->getCount());
         $this->assertSame(50, $adapter->getTotal());
         $this->assertSame(10, $adapter->getPerPage());
-        $this->assertSame(5, $adapter->getLastPage());
+        $this->assertSame(5, $adapter->getLast());
         $this->assertSame(4, $adapter->getNext());
     }
 }


### PR DESCRIPTION
See: https://docs.phalcon.io/4.0/en/upgrade#paginator
$total_items has been removed and $last should be used instead.